### PR TITLE
Update to new pyglet version

### DIFF
--- a/pygarrayimage/arrayimage.py
+++ b/pygarrayimage/arrayimage.py
@@ -35,7 +35,7 @@
 from pyglet.image import ImageData
 import ctypes
 
-__version__ = '1.0' # keep in sync with ../setup.py
+__version__ = '1.1' # keep in sync with ../setup.py
 __all__ = ['ArrayInterfaceImage']
 
 def is_c_contiguous(inter):
@@ -163,7 +163,7 @@ class ArrayInterfaceImage(ImageData):
         '''Force an update of the texture data.
         '''
 
-        texture = self.texture
+        texture = self.get_texture()
         internalformat = None
         self.blit_to_texture(
             texture.target, texture.level, 0, 0, 0, internalformat )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ TODO: support the buffer interface added with Python 2.6/3.0 rather
 than the numpy-defined array interface.
 
 """,
-      version='1.0', # keep in sync with pygarrayimage/arrayimage.py
+      version='1.1', # keep in sync with pygarrayimage/arrayimage.py
       author='Andrew Straw',
       author_email='strawman@astraw.com',
       url='http://code.astraw.com/projects/motmot/wiki/pygarrayimage',


### PR DESCRIPTION
Hey, long shot given your last commit is 2012, but...

Somewhere along the way, pyglet changed their texture interface.  This modification fixes the issue.

FWIW, I use this (old) library to render matplotlib animations in pyglet.  Maybe there's a more accepted, modern way to do that?